### PR TITLE
Parser now ignores blank lines

### DIFF
--- a/openair/openair.py
+++ b/openair/openair.py
@@ -9,7 +9,7 @@ def parseFile(filename):
     with open(filename, 'r') as file:
         for line in file:
             line = line.strip()
-            if line[0] == "*": continue
+            if len(line) == 0 or line[0] == "*": continue
             token, value = line.split(' ', 1)
             if token == "AC":
                 # new site


### PR DESCRIPTION
The parser fails on data exported from [open flightmaps](https://www.openflightmaps.org/ls-switzerland/?airac=2009&language=local) due to the blank lines in the document. This is fixed with a simple length check, ignoring blank lines alongside commented lines.